### PR TITLE
Update composer.json for Lumen 5.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "~5.0.17",
+        "illuminate/support": "5.1.*",
         "asm89/stack-cors": "0.2.x"
     },
     "autoload": {


### PR DESCRIPTION
This updates the illuminate/support to 5.1.\* dependency. This is an upgrade to support for Lumen 5.1.
